### PR TITLE
Fixed frees and \n error

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -7,20 +7,25 @@
 
 int PSH_READ();
 char **PSH_TOKENIZER(char *);
-int PSH_EXEC_EXTERNAL(char **);
+int PSH_EXEC_EXTERNAL(char **);   
 int PSH_EXIT(char **);
 int PSH_CD(char **);
 int PSH_ECHO(char **);
 int PSH_PWD(char **);
 int PSH_HISTORY(char **);
 
+
 // if u want to continue execution return 1 in built_in funcs
 
 char *builtin_str[] = {"exit", "cd", "echo", "pwd", "history"};
 
 int (*builtin_func[])(char **) = {
-    &PSH_EXIT, &PSH_CD, &PSH_ECHO, &PSH_PWD, &PSH_HISTORY}; // function pointer that takes in array of strings and
-                         // return an int)
+    &PSH_EXIT,
+    &PSH_CD,
+    &PSH_ECHO, 
+    &PSH_PWD, 
+    &PSH_HISTORY
+    }; // function pointer that takes in array of strings and return an int)
 
 int size_builtin_str = sizeof(builtin_str) / sizeof(builtin_str[0]); // number of built_in args
 
@@ -31,15 +36,16 @@ int main() {
 
 int PSH_EXIT(char **token_arr) {
   if (!token_arr[1]) {
-    printf("bye bye PSH :D\n"); // handling empty args and freeing token array
-                                // before leaving
+    printf("bye bye PSH :D\n"); // handling empty args and freeing token array before leaving
     free(token_arr);
-    exit(0);
+    return 0;
+    // exit(0);
   }
   printf("bye bye PSH :D\n");
   int exit_code = atoi(token_arr[1]);
   free(token_arr);
-  exit(exit_code);
+  return exit_code;
+  // exit(exit_code);
 }
 
 int PSH_CD(char **token_arr) { //kk
@@ -75,49 +81,38 @@ int PSH_HISTORY(char **token_arr) {
   //your code goes here Alayna
   return 1;
 } 
-
 int PSH_READ() {
   size_t n = 0;
-  int run = 1;
-
+  int run = 1     ;
   char *inputline = NULL;        // NULL is required to avoind conflicts with getline function
   while (run == 1) // if not done stack smashing occurs
   {
-  loopstart:
     printf("PSH $ ");
     if (getline(&inputline, &n, stdin) == -1) {
       perror("getline");
       free(inputline);
       return -1;
     }
-
     inputline[strcspn(inputline, "\n")] = '\0';
-    if (!strcmp(inputline, "\0")) {
-      goto loopstart;
-    }
     // getline takes \n as a part of string when pressed enter this.
     // line is used to remove that \n and changing it blank space
 
-    /* THIS IS NOW IMPLEMENTED AS A SEPERATE FUNCTION */
-
-    // if (strcmp(inputline, "exit") == 0) { // checks if the input is exit to
-    // quit
-    //   // printf("bye bye PSH :D");
-    //   free(inputline);
-    //   exit(0);
-    // }
     char **token_arr = PSH_TOKENIZER(inputline);
-
-    if (token_arr != NULL) {
+    if (token_arr[0]!= NULL)      //fixed \n giving seg fault
+    {
       int isinbuilt = 0;
       for (int i = 0; i < size_builtin_str; i++) {
-        if (!strcmp(token_arr[0], builtin_str[i])) {
-          // if(!strcmp(token_arr[0],"exit"))
-          // {
-          //   //  free(inputline);
-          // }
-          run = (*builtin_func[i])(token_arr);
+        if (strcmp(token_arr[0], builtin_str[i])==0)
+        {     
+          if(!strcmp(token_arr[0],"exit"))
+          {
+            run = (*builtin_func[i])(token_arr);
+            free(inputline);
+            exit(run);
+          }
+          run = (*builtin_func[i])(token_arr);  
           isinbuilt = 1;
+          break;
         } // frees token_arr
       }
       if (!isinbuilt)
@@ -162,7 +157,6 @@ char **PSH_TOKENIZER(char *line) {
   // }
   return token_arr;
 }
-
 int PSH_EXEC_EXTERNAL(char **token_arr) {
   pid_t pid, wpid;
   int status;


### PR DESCRIPTION
- ✅ Allocs and frees should now match and have **no leaks**
- ✅ Segmentation fault on entering empty command now **fixed** and will just continue to the prompt again
- ✅ Exit status return proper values now
'ls' command tested with various test cases and works as intended 